### PR TITLE
fix bug that created duplicated tables in the interface

### DIFF
--- a/src/main/java/controller/MainController.java
+++ b/src/main/java/controller/MainController.java
@@ -148,7 +148,6 @@ public class MainController {
 		excelRows = ei.getAllRows();
 		convertExcelRows();
 		gui = new MainFrame(createExcelTable(), rulesList);
-		qualityGui = new QualityRulesResultFrame();
 		gui.getCheckQualityButton().addActionListener(e -> checkCodeQualityAndShow());
 
 		editButton(this.gui.getEditButton(), this.gui.getRulesComboBox());
@@ -250,6 +249,10 @@ public class MainController {
 
 		if (results != null) {
 			qualityIndicator = new QualityIndicator(results);
+			if (qualityGui != null) {
+				qualityGui.hide();
+			}
+			qualityGui = new QualityRulesResultFrame();
 			qualityGui.fillFrame(results, colNames, qualityIndicator);
 			qualityGui.show();
 		}
@@ -281,6 +284,7 @@ public class MainController {
 					ruleIterator++;
 				} catch (ScriptException e) {
 					qualityGui.hide();
+					qualityGui = null;
 					JOptionPane.showMessageDialog(null,
 							"Invalid rule syntax! Please verify the conditions for the rule  \"" + rule + "\"!");
 					return null;

--- a/src/main/java/gui/QualityRulesResultFrame.java
+++ b/src/main/java/gui/QualityRulesResultFrame.java
@@ -73,6 +73,7 @@ public class QualityRulesResultFrame {
 	 */
 	public void hide() {
 		qualityFrame.setVisible(false);
+		qualityFrame.dispose();
 	}
 
 	/**

--- a/src/main/java/model/Condition.java
+++ b/src/main/java/model/Condition.java
@@ -1,9 +1,0 @@
-package main.java.model;
-
-/**
- * Simple enum holding two conditions: AND and OR.
- * 
- */
-public enum Condition {
-	AND, OR
-}


### PR DESCRIPTION
There was a bug where the quality results gui would duplicate the content on every repaint because we were adding new frames on top of the existing ones. This clears old frames and always build a new.